### PR TITLE
Write edn to file using pprint for readability

### DIFF
--- a/src/reifyhealth/src_munch/gallery/colors/parse.cljs
+++ b/src/reifyhealth/src_munch/gallery/colors/parse.cljs
@@ -118,7 +118,7 @@
   "Creates resources/public/gallery-color-data.edn, to be used directly by the gallery
   to generate the color swatches."
   [{:keys [color-edn-filepath color-edn] :as acc}]
-  (spit color-edn-filepath color-edn)
+  (spit color-edn-filepath (with-out-str (pprint color-edn)))
   acc)
 
 (defn- cleanup

--- a/src/reifyhealth/src_munch/gallery/icons/parse.cljs
+++ b/src/reifyhealth/src_munch/gallery/icons/parse.cljs
@@ -53,7 +53,7 @@
   "Creates resources/public/gallery-icon-data.edn, to be used directly by the gallery
   to generate the icons in the Iconography section."
   [to-output-filepath parsed-icons]
-  (spit to-output-filepath parsed-icons))
+  (spit to-output-filepath (with-out-str (pprint parsed-icons))))
 
 (defn- parse-html
   "Parse the icomoon svg file for the icon data it holds"


### PR DESCRIPTION
While reconciling differences between icomoon and salk, it became
clear that a pprint'ed format would make it easier to see the
difference.